### PR TITLE
feat: support point and linestring

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -4,4 +4,4 @@ dist
 dist-ssr
 *.local
 yarn-error.log
-public/sample_mvt
+public/*

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,34 +233,22 @@ export class MVTImageryProvider implements ImageryProviderTrait {
         continue;
       }
 
+      const style = this._style?.(feature, requestedTile);
+      if (style) {
+        context.fillStyle = style.fillStyle ?? context.fillStyle;
+        context.strokeStyle = style.strokeStyle ?? context.strokeStyle;
+        context.lineWidth = style.lineWidth ?? context.lineWidth;
+        context.lineJoin = style.lineJoin ?? context.lineJoin;
+      }
+
       if (VectorTileFeature.types[feature.type] === "Polygon") {
-        const style = this._style?.(feature, requestedTile);
-        if (style) {
-          context.fillStyle = style.fillStyle ?? context.fillStyle;
-          context.strokeStyle = style.strokeStyle ?? context.strokeStyle;
-          context.lineWidth = style.lineWidth ?? context.lineWidth;
-          context.lineJoin = style.lineJoin ?? context.lineJoin;
-        }
-
-        context.beginPath();
-
-        const coordinates = feature.loadGeometry();
-
-        // Polygon rings
-        for (let i2 = 0; i2 < coordinates.length; i2++) {
-          let pos = coordinates[i2][0];
-          context.moveTo(pos.x * extentFactor, pos.y * extentFactor);
-
-          // Polygon ring points
-          for (let j = 1; j < coordinates[i2].length; j++) {
-            pos = coordinates[i2][j];
-            context.lineTo(pos.x * extentFactor, pos.y * extentFactor);
-          }
-        }
-        context.stroke();
-        context.fill();
+        this._renderPolygon(context, feature, extentFactor);
+      } else if (VectorTileFeature.types[feature.type] === "Point") {
+        this._renderPoint(context, feature, extentFactor);
+      } else if (VectorTileFeature.types[feature.type] === "LineString") {
+        this._renderLineString(context, feature, extentFactor);
       } else {
-        console.log(
+        console.error(
           `Unexpected geometry type: ${feature.type} in region map on tile ${[
             requestedTile.level,
             requestedTile.x,
@@ -273,6 +261,73 @@ export class MVTImageryProvider implements ImageryProviderTrait {
     this._onFeaturesRendered?.();
 
     return canvas;
+  }
+
+  _renderPolygon(
+    context: CanvasRenderingContext2D,
+    feature: VectorTileFeature,
+    extentFactor: number,
+  ) {
+    context.beginPath();
+
+    const coordinates = feature.loadGeometry();
+
+    // Polygon rings
+    for (let i2 = 0; i2 < coordinates.length; i2++) {
+      let pos = coordinates[i2][0];
+      context.moveTo(pos.x * extentFactor, pos.y * extentFactor);
+
+      // Polygon ring points
+      for (let j = 1; j < coordinates[i2].length; j++) {
+        pos = coordinates[i2][j];
+        context.lineTo(pos.x * extentFactor, pos.y * extentFactor);
+      }
+    }
+    context.stroke();
+    context.fill();
+  }
+
+  _renderPoint(
+    context: CanvasRenderingContext2D,
+    feature: VectorTileFeature,
+    extentFactor: number,
+  ) {
+    context.beginPath();
+
+    const coordinates = feature.loadGeometry();
+
+    for (let i2 = 0; i2 < coordinates.length; i2++) {
+      const pos = coordinates[i2][0];
+      const [x, y] = [pos.x * extentFactor, pos.y * extentFactor];
+
+      // Handle lineWidth as radius
+      const radius = context.lineWidth;
+
+      context.beginPath();
+      context.arc(x, y, radius, 0, 2 * Math.PI);
+      context.fill();
+    }
+  }
+
+  _renderLineString(
+    context: CanvasRenderingContext2D,
+    feature: VectorTileFeature,
+    extentFactor: number,
+  ) {
+    context.beginPath();
+
+    const coordinates = feature.loadGeometry();
+
+    for (let i2 = 0; i2 < coordinates.length; i2++) {
+      let pos = coordinates[i2][0];
+      context.moveTo(pos.x * extentFactor, pos.y * extentFactor);
+
+      for (let j = 1; j < coordinates[i2].length; j++) {
+        pos = coordinates[i2][j];
+        context.lineTo(pos.x * extentFactor, pos.y * extentFactor);
+      }
+    }
+    context.stroke();
   }
 
   async pickFeatures(

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ export class MVTImageryProvider implements ImageryProviderTrait {
         context.lineJoin = style.lineJoin ?? context.lineJoin;
 
         if (VectorTileFeature.types[feature.type] === "Polygon") {
-          this._renderPolygon(context, feature, extentFactor);
+          this._renderPolygon(context, feature, extentFactor, (style.lineWidth ?? 1) > 0);
         } else if (VectorTileFeature.types[feature.type] === "Point") {
           this._renderPoint(context, feature, extentFactor);
         } else if (VectorTileFeature.types[feature.type] === "LineString") {
@@ -288,6 +288,7 @@ export class MVTImageryProvider implements ImageryProviderTrait {
             ].join("/")}`,
           );
         }
+      }
     });
 
     this._onFeaturesRendered?.();
@@ -299,6 +300,7 @@ export class MVTImageryProvider implements ImageryProviderTrait {
     context: CanvasRenderingContext2D,
     feature: VectorTileFeature,
     extentFactor: number,
+    shouldRenderLine: boolean,
   ) {
     context.beginPath();
 
@@ -316,7 +318,7 @@ export class MVTImageryProvider implements ImageryProviderTrait {
       }
     }
 
-    if ((style.lineWidth ?? 1) > 0) {
+    if (shouldRenderLine) {
       context.stroke();
     }
     context.fill();


### PR DESCRIPTION
I implemented point and linestring support, but I can't test it. Because I can't find test data.
To implement it, I referred [MVT specification](https://github.com/mapbox/vector-tile-spec/tree/master/2.1).
- [About implementation of linestring on specification](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4343-linestring-geometry-type)
- [About implementation of point on specification](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4342-point-geometry-type)

|Point|Line|
|:--:|:--:|
|![Screenshot 2023-04-10 at 18 20 10](https://user-images.githubusercontent.com/34934510/230873602-0381e587-e373-467b-b503-b27b02193c4b.png)|![Screenshot 2023-04-10 at 18 18 14](https://user-images.githubusercontent.com/34934510/230873638-9a9d162c-785d-471c-855f-f21044fe161c.png)|