### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cesium-mvt-imagery-provider
+  namespace: reearth
+  description: Render MVT data on Cesium
+  annotations:
+    github.com/project-slug: reearth/cesium-mvt-imagery-provider
+  links:
+  - url: https://github.com/reearth/cesium-mvt-imagery-provider
+    title: GitHub
+    icon: github
+  tags:
+  - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/lib


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `cesium-mvt-imagery-provider` (namespace `reearth`)
- **Owner:** `reearth/lib`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.